### PR TITLE
Update for hop-client 0.1

### DIFF
--- a/hop/apps/slack/slack_app.py
+++ b/hop/apps/slack/slack_app.py
@@ -119,7 +119,7 @@ def prepare_message(gcn):
         Returns:
             Formated GCN message for pretty printing
     """
-    gcn_json = json.dumps(gcn.asdict())
+    gcn_dict = gcn.asdict()
     return (
         "*Title:* {title}\n"
         "*Number:* {number}\n"
@@ -127,7 +127,7 @@ def prepare_message(gcn):
         "*Date*: {date}\n"
         "*From:* {from}\n\n"
         "{body}"
-    ).format(**gcn_json["header"], body=gcn_json["body"])
+    ).format(**gcn_dict["header"], body=gcn_dict["body"])
 
 
 # ------------------------------------------------

--- a/hop/apps/slack/slack_app.py
+++ b/hop/apps/slack/slack_app.py
@@ -6,9 +6,7 @@ __description__ = "Post received messages to Slack channel"
 import argparse
 import configparser
 import requests
-import json
 
-from hop import Stream
 from hop import cli
 from hop import io
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "hop-client >= 0.0.5a1", "requests", "slackclient"
+    "hop-client >= 0.1", "requests", "slackclient"
 ]
 extras_require = {
     'dev': ['pytest', 'pytest-console-scripts', 'pytest-cov', 'flake8', 'flake8-black', 'pytest-datadir'],

--- a/tests/test_slack_post.py
+++ b/tests/test_slack_post.py
@@ -3,6 +3,8 @@
 import pytest
 from unittest.mock import patch
 import configparser
+import json
+from hop.models import GCNCircular
 from hop.apps.slack import slack_app
 from hop.apps.slack import __version__
 
@@ -26,7 +28,8 @@ def test_message_preparation_for_slack(shared_datadir):
     ).read_text()
     with patch("hop.apps.slack.slack_app.json.dumps") as mock_load:
         mock_load.return_value = test_content
-        test_result = slack_app.prepare_message(test_content)
+        circular = GCNCircular(**json.loads(test_content))
+        test_result = slack_app.prepare_message(circular)
         with open("file2.txt", "w") as f:
             f.write(test_result)
         assert (

--- a/tests/test_slack_post.py
+++ b/tests/test_slack_post.py
@@ -26,18 +26,16 @@ def test_message_preparation_for_slack(shared_datadir):
     test_content = (
         shared_datadir / "test_data" / "26936_gcn_circular_dict.json"
     ).read_text()
-    with patch("hop.apps.slack.slack_app.json.dumps") as mock_load:
-        mock_load.return_value = test_content
-        circular = GCNCircular(**json.loads(test_content))
-        test_result = slack_app.prepare_message(circular)
-        with open("file2.txt", "w") as f:
-            f.write(test_result)
-        assert (
-            test_result
-            == (
-                shared_datadir / "expected_data" / "26936_gcn_circular_PP.txt"
-            ).read_text()
-        )
+    circular = GCNCircular(**json.loads(test_content))
+    test_result = slack_app.prepare_message(circular)
+    with open("file2.txt", "w") as f:
+        f.write(test_result)
+    assert (
+        test_result
+        == (
+            shared_datadir / "expected_data" / "26936_gcn_circular_PP.txt"
+        ).read_text()
+    )
 
 
 def test_parse_slack_config(shared_datadir, capsys):


### PR DESCRIPTION
## Description

This PR updates the relevant bits to make it compatible with hop-client 0.1. In particular, much of the command line handling has been simplified as a result. It may be worth exposing the 'subscribe' options in hop-client so they can be imported rather than redefined here. One thing this doesn't address is the auth config format and where it should be located, but I'm not sure this is the appropriate place to update this, but bringing this up to be aware of it when this is tested.

It would also be great to get an independent verification that this works correctly.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
